### PR TITLE
Allow parsing localtime

### DIFF
--- a/gpx.go
+++ b/gpx.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
-const timeLayout = "2006-01-02T15:04:05.999999999Z"
+const timeLayout = time.RFC3339Nano
 
 // StartElement is the XML start element for GPX files.
 var StartElement = xml.StartElement{


### PR DESCRIPTION
I ran into a parsing problem with a GPX file which used Local time instead of UTC time. The wording in the spec is a little inconsistent around whether local times are supported or not, but it seems like there are valid GPX file which use Local time.

This should allow parsing timestamps with either local or UTC time, but still only output UTC times.

I used this thread as a reference as well as the GPX 1.1 spec: https://qlandkartegt-users.narkive.com/0mbEZwrT/time-zone-in-gpx-files
