### PR TITLE
Migrate xsd file URI scheme from http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Package `gpx` provides convenince methods for reading and writing GPX documents.
 ```go
 r := bytes.NewBufferString(`
     <?xml version="1.0" encoding="UTF-8"?>
-    <gpx version="1.0" creator="ExpertGPS 1.1 - http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/0" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+    <gpx version="1.1" creator="ExpertGPS 1.1 - http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd">
         <wpt lat="42.438878" lon="-71.119277">
         <ele>44.586548</ele>
         <time>2001-11-28T21:05:28Z</time>
@@ -27,14 +27,14 @@ if err != nil {
 }
 fmt.Printf("t.Wpt[0] == %+v", t.Wpt[0])
 // Output:
-// t.Wpt[0] == &{Lat:42.438878 Lon:-71.119277 Ele:44.586548 Time:2001-11-28 21:05:28 +0000 UTC MagVar:0 GeoidHeight:0 Name:5066 Cmt: Desc:5066 Src: Link:[] Sym:Crossing Type:Crossing Fix: Sat:0 HDOP:0 VDOP:0 PDOP:0 AgeOfDGPSData:0 DGPSID:[] Extensions:<nil>}
+// t.Wpt[0] == &{Lat:42.438878 Lon:-71.119277 Ele:44.586548 Speed:0 Course:0 Time:2001-11-28 21:05:28 +0000 UTC MagVar:0 GeoidHeight:0 Name:5066 Cmt: Desc:5066 Src: Link:[] Sym:Crossing Type:Crossing Fix: Sat:0 HDOP:0 VDOP:0 PDOP:0 AgeOfDGPSData:0 DGPSID:[] Extensions:<nil>}
 ```
 
 ## Write example
 
 ```go
 g := &gpx.GPX{
-    Version: "1.0",
+    Version: "1.1",
     Creator: "ExpertGPS 1.1 - http://www.topografix.com",
     Wpt: []*gpx.WptType{
         {
@@ -57,7 +57,7 @@ if err := g.WriteIndent(os.Stdout, "", "  "); err != nil {
 }
 // Output:
 // <?xml version="1.0" encoding="UTF-8"?>
-// <gpx version="1.0" creator="ExpertGPS 1.1 - http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/0" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+// <gpx version="1.1" creator="ExpertGPS 1.1 - http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd">
 //   <wpt lat="42.438878" lon="-71.119277">
 //     <ele>44.586548</ele>
 //     <time>2001-11-28T21:05:28Z</time>

--- a/gpx.go
+++ b/gpx.go
@@ -15,7 +15,11 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
-const timeLayout = time.RFC3339Nano
+const (
+	timeLayout = time.RFC3339Nano
+	http       = "http://"
+	https      = "https://"
+)
 
 // StartElement is the XML start element for GPX files.
 var StartElement = xml.StartElement{
@@ -196,10 +200,10 @@ func Read(r io.Reader) (*GPX, error) {
 
 // MarshalXML implements xml.Marshaler.MarshalXML.
 func (g *GPX) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
-	baseURL := "http://www.topografix.com/GPX/" + strings.Join(strings.Split(g.Version, "."), "/")
+	baseURL := "www.topografix.com/GPX/" + strings.Join(strings.Split(g.Version, "."), "/")
 	xmlSchemaLocations := append([]string{
-		baseURL,
-		baseURL + "/gpx.xsd",
+		http + baseURL,
+		https + baseURL + "/gpx.xsd",
 	}, g.XMLSchemaLocations...)
 	attr := []xml.Attr{
 		{
@@ -212,11 +216,11 @@ func (g *GPX) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 		},
 		{
 			Name:  xml.Name{Local: "xmlns:xsi"},
-			Value: "http://www.w3.org/2001/XMLSchema-instance",
+			Value: http + "www.w3.org/2001/XMLSchema-instance",
 		},
 		{
 			Name:  xml.Name{Local: "xmlns"},
-			Value: baseURL,
+			Value: http + baseURL,
 		},
 		{
 			Name:  xml.Name{Local: "xsi:schemaLocation"},

--- a/gpx_examples_test.go
+++ b/gpx_examples_test.go
@@ -13,7 +13,7 @@ import (
 func ExampleRead() {
 	r := bytes.NewBufferString(`
 		<?xml version="1.0" encoding="UTF-8"?>
-		<gpx version="1.0" creator="ExpertGPS 1.1 - http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/0" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+		<gpx version="1.1" creator="ExpertGPS 1.1 - http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd">
 		  <wpt lat="42.438878" lon="-71.119277">
 			<ele>44.586548</ele>
 			<speed>9.16</speed>
@@ -37,7 +37,7 @@ func ExampleRead() {
 
 func ExampleGPX_WriteIndent() {
 	g := &gpx.GPX{
-		Version: "1.0",
+		Version: "1.1",
 		Creator: "ExpertGPS 1.1 - http://www.topografix.com",
 		Wpt: []*gpx.WptType{
 			{
@@ -60,7 +60,7 @@ func ExampleGPX_WriteIndent() {
 	}
 	// Output:
 	// <?xml version="1.0" encoding="UTF-8"?>
-	// <gpx version="1.0" creator="ExpertGPS 1.1 - http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/0" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+	// <gpx version="1.1" creator="ExpertGPS 1.1 - http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd">
 	//   <wpt lat="42.438878" lon="-71.119277">
 	//     <ele>44.586548</ele>
 	//     <time>2001-11-28T21:05:28Z</time>

--- a/gpx_test.go
+++ b/gpx_test.go
@@ -466,24 +466,24 @@ func TestRoundTrip(t *testing.T) {
 	}{
 		{
 			data: "<gpx" +
-				" version=\"1.0\"" +
+				" version=\"1.1\"" +
 				" creator=\"ExpertGPS 1.1 - http://www.topografix.com\"" +
 				" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
-				" xmlns=\"http://www.topografix.com/GPX/1/0\"" +
-				" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd\">" +
+				" xmlns=\"http://www.topografix.com/GPX/1/1\"" +
+				" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd\">" +
 				"</gpx>",
 			gpx: &gpx.GPX{
-				Version: "1.0",
+				Version: "1.1",
 				Creator: "ExpertGPS 1.1 - http://www.topografix.com",
 			},
 		},
 		{
 			data: "<gpx" +
-				" version=\"1.0\"" +
+				" version=\"1.1\"" +
 				" creator=\"ExpertGPS 1.1 - http://www.topografix.com\"" +
 				" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
-				" xmlns=\"http://www.topografix.com/GPX/1/0\"" +
-				" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd\">\n" +
+				" xmlns=\"http://www.topografix.com/GPX/1/1\"" +
+				" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd\">\n" +
 				"\t<wpt lat=\"42.438878\" lon=\"-71.119277\">\n" +
 				"\t\t<ele>44.586548</ele>\n" +
 				"\t\t<time>2001-11-28T21:05:28Z</time>\n" +
@@ -494,7 +494,7 @@ func TestRoundTrip(t *testing.T) {
 				"\t</wpt>\n" +
 				"</gpx>",
 			gpx: &gpx.GPX{
-				Version: "1.0",
+				Version: "1.1",
 				Creator: "ExpertGPS 1.1 - http://www.topografix.com",
 				Wpt: []*gpx.WptType{
 					{
@@ -512,11 +512,11 @@ func TestRoundTrip(t *testing.T) {
 		},
 		{
 			data: "<gpx" +
-				" version=\"1.0\"" +
+				" version=\"1.1\"" +
 				" creator=\"ExpertGPS 1.1 - http://www.topografix.com\"" +
 				" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
-				" xmlns=\"http://www.topografix.com/GPX/1/0\"" +
-				" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd\">\n" +
+				" xmlns=\"http://www.topografix.com/GPX/1/1\"" +
+				" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd\">\n" +
 				"\t<rte>\n" +
 				"\t\t<name>BELLEVUE</name>\n" +
 				"\t\t<desc>Bike Loop Bellevue</desc>\n" +
@@ -541,7 +541,7 @@ func TestRoundTrip(t *testing.T) {
 				"\t</rte>\n" +
 				"</gpx>",
 			gpx: &gpx.GPX{
-				Version: "1.0",
+				Version: "1.1",
 				Creator: "ExpertGPS 1.1 - http://www.topografix.com",
 				Rte: []*gpx.RteType{
 					{

--- a/testdata/ashland.gpx
+++ b/testdata/ashland.gpx
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
 <?xml-stylesheet type="text/xsl" href="details.xsl"?>
 <gpx
- version="1.0"
+ version="1.1"
  creator="ExpertGPS 1.1.1 - http://www.topografix.com"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xmlns="http://www.topografix.com/GPX/1/0"
+ xmlns="http://www.topografix.com/GPX/1/1"
  xmlns:topografix="http://www.topografix.com/GPX/Private/TopoGrafix/0/1"
- xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd http://www.topografix.com/GPX/Private/TopoGrafix/0/1 http://www.topografix.com/GPX/Private/TopoGrafix/0/1/topografix.xsd">
+ xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd http://www.topografix.com/GPX/Private/TopoGrafix/0/1 https://www.topografix.com/GPX/Private/TopoGrafix/0/1/topografix.xsd">
 <name><![CDATA[Rockbuster Duathlon at Ashland State Park]]></name>
 <desc><![CDATA[Team TopoGrafix tracklogs from the Rockbuster Duathlon at Ashland State Park, April 21st, 2002.  The course consisted of a two-mile run, an seven mile mountain bike course, and a final two-mile run.
 

--- a/testdata/fells_loop.gpx
+++ b/testdata/fells_loop.gpx
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <gpx
- version="1.0"
+ version="1.1"
  creator="ExpertGPS 1.1 - http://www.topografix.com"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xmlns="http://www.topografix.com/GPX/1/0"
- xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+ xmlns="http://www.topografix.com/GPX/1/1"
+ xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd">
 <time>2002-02-27T17:18:33Z</time>
 <bounds minlat="42.401051" minlon="-71.126602" maxlat="42.468655" maxlon="-71.102973"/>
 <wpt lat="42.438878" lon="-71.119277">

--- a/testdata/mystic_basin_trail.gpx
+++ b/testdata/mystic_basin_trail.gpx
@@ -4,7 +4,7 @@
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xmlns="http://www.topografix.com/GPX/1/1"
 	 xmlns:topografix="http://www.topografix.com/GPX/Private/TopoGrafix/0/1"
-     xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+     xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd">
 	<metadata>
 		<name><![CDATA[Mystic River Basin Trails]]></name>
 		<desc><![CDATA[Both banks of the lower Mystic River have paved trails, allowing for a short and a long loop along the water.  The short loop is a two mile trail with no road crossings.  The long loop adds side-trips out to Draw Seven Park and the MBTA yard at Wellington Station, but crosses the six lanes of Route 28 twice.]]></desc>


### PR DESCRIPTION
The change eliminates the 301 Moved Permanently redirect

Additional change includes updating the TopoGrafix version from 1.0 to 1.1 in the read and write example